### PR TITLE
buster-static is incompatible with ramp-resources 0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "buster-core": ">=0.6.2",
         "buster-cli": ">=0.5",
         "buster-test": ">=0.6",
-        "ramp-resources": ">=0.4",
+        "ramp-resources": "~0.4",
         "mkdirp": "~0.3"
     },
     "devDependencies": {


### PR DESCRIPTION
Remain on ramp-resources 0.4.x releases
