### PR TITLE
Add html5 doctype to test bed

### DIFF
--- a/lib/index.html
+++ b/lib/index.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html>
   <head>
     <title>Buster.JS</title>


### PR DESCRIPTION
The docs (http://docs.busterjs.org/en/latest/overview/#custom-test-beds)
indicate that the test bed 'defaults to a plain HTML5 document.' Yet
there was no doctype. This commit adds an html5 doctype to the test bed.

Adding a doctype will force IE into standards compliant mode instead of
the default quirks mode. As standards mode is strongly encouraged for new
development, it should be the default for buster as well.
